### PR TITLE
[RFC] Fix clang-scan issues

### DIFF
--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -845,8 +845,7 @@ static colnr_T hardcopy_line(prt_settings_T *psettings, int page_line, prt_pos_T
    * Loop over the columns until the end of the file line or right margin.
    */
   for (col = ppos->column; line[col] != NUL && !need_break; col += outputlen) {
-    outputlen = 1;
-    if (has_mbyte && (outputlen = (*mb_ptr2len)(line + col)) < 1)
+    if ((outputlen = (*mb_ptr2len)(line + col)) < 1)
       outputlen = 1;
     /*
      * syntax highlighting stuff.

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -845,11 +845,10 @@ static colnr_T hardcopy_line(prt_settings_T *psettings, int page_line, prt_pos_T
    * Loop over the columns until the end of the file line or right margin.
    */
   for (col = ppos->column; line[col] != NUL && !need_break; col += outputlen) {
-    if ((outputlen = (*mb_ptr2len)(line + col)) < 1)
+    if ((outputlen = (*mb_ptr2len)(line + col)) < 1) {
       outputlen = 1;
-    /*
-     * syntax highlighting stuff.
-     */
+    }
+    // syntax highlighting stuff.
     if (psettings->do_syntax) {
       id = syn_get_id(curwin, ppos->file_line, col, 1, NULL, FALSE);
       if (id > 0)

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -270,32 +270,16 @@ void trunc_string(char_u *s, char_u *buf, int room, int buflen)
   }
 
   /* Last part: End of the string. */
-  i = e;
-  if (enc_dbcs != 0) {
-    /* For DBCS going backwards in a string is slow, but
-     * computing the cell width isn't too slow: go forward
-     * until the rest fits. */
-    n = vim_strsize(s + i);
-    while (len + n > room) {
-      n -= ptr2cells(s + i);
-      i += (*mb_ptr2len)(s + i);
-    }
-  } else if (enc_utf8) {
-    /* For UTF-8 we can go backwards easily. */
-    half = i = (int)STRLEN(s);
-    for (;; ) {
-      do
-        half = half - (*mb_head_off)(s, s + half - 1) - 1;
-      while (utf_iscomposing(utf_ptr2char(s + half)) && half > 0);
-      n = ptr2cells(s + half);
-      if (len + n > room)
-        break;
-      len += n;
-      i = half;
-    }
-  } else {
-    for (i = (int)STRLEN(s); len + (n = ptr2cells(s + i - 1)) <= room; --i)
-      len += n;
+  half = i = (int)STRLEN(s);
+  for (;; ) {
+    do
+      half = half - (*mb_head_off)(s, s + half - 1) - 1;
+    while (utf_iscomposing(utf_ptr2char(s + half)) && half > 0);
+    n = ptr2cells(s + half);
+    if (len + n > room)
+      break;
+    len += n;
+    i = half;
   }
 
   if (i <= e + 3) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -269,15 +269,16 @@ void trunc_string(char_u *s, char_u *buf, int room, int buflen)
       }
   }
 
-  /* Last part: End of the string. */
+  // Last part: End of the string.
   half = i = (int)STRLEN(s);
-  for (;; ) {
-    do
+  for (;;) {
+    do {
       half = half - (*mb_head_off)(s, s + half - 1) - 1;
-    while (utf_iscomposing(utf_ptr2char(s + half)) && half > 0);
+    } while (utf_iscomposing(utf_ptr2char(s + half)) && half > 0);
     n = ptr2cells(s + half);
-    if (len + n > room)
+    if (len + n > room) {
       break;
+    }
     len += n;
     i = half;
   }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1405,7 +1405,6 @@ void ins_char_bytes(char_u *buf, size_t charlen)
     coladvance_force(getviscol());
   }
 
-  int c = buf[0];
   size_t col = (size_t)curwin->w_cursor.col;
   linenr_T lnum = curwin->w_cursor.lnum;
   char_u *oldp = ml_get(lnum);
@@ -1498,10 +1497,7 @@ void ins_char_bytes(char_u *buf, size_t charlen)
       && msg_silent == 0
       && !ins_compl_active()
       ) {
-    if (has_mbyte)
-      showmatch(mb_ptr2char(buf));
-    else
-      showmatch(c);
+    showmatch(mb_ptr2char(buf));
   }
 
   if (!p_ri || (State & REPLACE_FLAG)) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4885,7 +4885,7 @@ void win_redr_status(win_T *wp)
     if (this_ru_col <= 1) {
       p = (char_u *)"<";                /* No room for file name! */
       len = 1;
-    } else if (has_mbyte) {
+    } else {
       int clen = 0, i;
 
       /* Count total number of display cells. */
@@ -4902,11 +4902,6 @@ void win_redr_status(win_T *wp)
         *p = '<';
         ++len;
       }
-
-    } else if (len > this_ru_col - 1) {
-      p += len - (this_ru_col - 1);
-      *p = '<';
-      len = this_ru_col - 1;
     }
 
     row = wp->w_winrow + wp->w_height;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4876,7 +4876,7 @@ void win_redr_status(win_T *wp)
     }
     if (wp->w_buffer->b_p_ro) {
       STRCPY(p + len, _("[RO]"));
-      len += 4;
+      len += (int)STRLEN(p + len);
     }
 
     this_ru_col = ru_col - (Columns - wp->w_width);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4880,22 +4880,24 @@ void win_redr_status(win_T *wp)
     }
 
     this_ru_col = ru_col - (Columns - wp->w_width);
-    if (this_ru_col < (wp->w_width + 1) / 2)
+    if (this_ru_col < (wp->w_width + 1) / 2) {
       this_ru_col = (wp->w_width + 1) / 2;
+    }
     if (this_ru_col <= 1) {
-      p = (char_u *)"<";                /* No room for file name! */
+      p = (char_u *)"<";                // No room for file name!
       len = 1;
     } else {
       int clen = 0, i;
 
-      /* Count total number of display cells. */
-      clen = (int) mb_string2cells(p);
+      // Count total number of display cells.
+      clen = (int)mb_string2cells(p);
 
-      /* Find first character that will fit.
-       * Going from start to end is much faster for DBCS. */
+      // Find first character that will fit.
+      // Going from start to end is much faster for DBCS.
       for (i = 0; p[i] != NUL && clen >= this_ru_col - 1;
-           i += (*mb_ptr2len)(p + i))
+           i += (*mb_ptr2len)(p + i)) {
         clen -= (*mb_ptr2cells)(p + i);
+      }
       len = clen;
       if (i > 0) {
         p = p + i - 1;

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -979,7 +979,6 @@ int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap,
           const void *ptr_arg = NULL;
 
           if (fmt_spec == 'p') {
-            length_modifier = '\0';
             ptr_arg = tvs ? tv_ptr(tvs, &arg_idx) : va_arg(ap, void *);
             if (ptr_arg) {
               arg_sign = 1;


### PR DESCRIPTION
Maybe we should change branch names, since we do not fix dead stores anymore.

As a side note, there are about 300 other occurrences of if statements that use `has_mbyte` that we could remove..

It would be nice to fix all issues in https://neovim.io/doc/reports/clang/ :
- [ ] Dead assignment	in eval/typval_encode.c.h, function encode_vim_to_object on line 716
- [ ] Dead assignment	in eval/typval_encode.c.h, function encode_vim_to_string on line 716
- [ ] Dead assignment	in eval/typval_encode.c.h, function encode_vim_to_echo on line 716
- [ ] Dead assignment	in eval/typval_encode.c.h, function encode_vim_to_json on line 716
- [ ] Dead assignment	in eval/typval_encode.c.h, function encode_vim_to_msgpack on line 716
- [x] Dead assignment	in hardcopy.c, function hardcopy_line on line 848
  - [x] discussed
- [x] Dead assignment	in message.c, function trunc_string on line 273
  - [x] discussed
- [x] Dead initialization	in misc1.c, function ins_char_bytes on line 1408
  - [x] discussed
- [ ] Dead assignment	in screen.c, function win_line on line 3077
  * Probably shouldn't touch this one, as it is inside a 2000 line function filled with inconsistencies. It will probably not be appreciated if we fix a small part of it and leave the rest alone.
- [x] Dead increment	in screen.c, function win_redr_status on line 4879
  - [x] discussed
- [x] Dead assignment	in strings.c, function vim_vsnprintf on line 982
  - [x] discussed